### PR TITLE
Fix endless waiting for the next updater

### DIFF
--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -230,7 +230,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
 {
 	if ([note object] == self.driver && (nil == self.driver || [self.driver finished]))
 	{
-        if ([self.delegate conformsToProtocol:@protocol(SUUpdaterDelegatePrivate)]) {
+        if ([self.delegate respondsToSelector:@selector(updaterDidEndUpdateProcess:)]) {
             [(id<SUUpdaterDelegatePrivate>)self.delegate updaterDidEndUpdateProcess:self];
         }
 
@@ -321,7 +321,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
 	if ([self updateInProgress]) { return; }
 	if (self.checkTimer) { [self.checkTimer invalidate]; self.checkTimer = nil; }		// Timer is non-repeating, may have invalidated itself, so we had to retain it.
 
-    if ([self.delegate conformsToProtocol:@protocol(SUUpdaterDelegatePrivate)]) {
+    if ([self.delegate respondsToSelector:@selector(updaterWillStartUpdateProcess:)]) {
         [(id<SUUpdaterDelegatePrivate>)self.delegate updaterWillStartUpdateProcess:self];
     }
     


### PR DESCRIPTION
`SUUpdaterQueue` changes its updaters' `delegates` to a proxy one (`SUDelegateProxy`) and it conforms to `SUUpdaterDelegatePrivate`. The proxy delegate proxies some methods to real delegate only and some to `SUUpdaterQueue`. `conformsToProtocol` is not proxied to `SUUpdaterQueue`, but to `CMUpdateManager`. `CMUpdateManager` cannot conform to `SUUpdaterDelegatePrivate` because it's private, obviously, so the check is failed and the update never ends.

**Solution**: Change checking from checking for a selector to checking to responding. I'm ok with the solution because for me it's better to check for responding, then what it exact is 

Other possible solution is:
1. `@interface SUUpdaterQueue () <SUUpdaterDelegatePrivate>`
2. Extend a list of forwarded selectors in SUDelegateProxy with `conformsToProtocol`
Here's the diff for the solution:
![image](https://user-images.githubusercontent.com/2575555/54413193-86939580-46fd-11e9-8d33-112f72e32c2d.png)

What do you think, guys? 